### PR TITLE
feat(rules): per‑rule enable/disable with UI toggle and matcher support

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,6 +57,12 @@ This is the live backlog. Completed items have been moved to `TODO.v0.0.1.md`.
 - [x] Rules actions icon‑only (Edit/Delete) with visually‑hidden labels
 - [x] Help tooltip icon for rules ordering next to “Current rules”
 
+### Rules Table polish (next)
+
+- [ ] Conflict badges: replace "Never matches" / "May not match" text with icon-only badges and keep details in a tooltip/popover.
+- [ ] Columns: move Method before URL / Path; set a fixed width for method badges sufficient for "DELETE".
+- [ ] Delay column: rename header to "Delay (ms)"; in rows, display just the number (no "ms" suffix).
+
 ## QA & Validation
 
 - [ ] Fresh install: create project, add rules, verify throttling
@@ -239,12 +245,12 @@ Prevent accidental deletions by confirming intent before removing a rule.
 
 Allow turning individual rules on/off without deleting them. Disabled rules should be ignored by matching logic.
 
-- [ ] Extend `Rule` type with `enabled?: boolean` (default true)
-- [ ] Migration: on load, treat missing `enabled` as true (no storage rewrite required initially)
-- [ ] UI: add a toggle column after Actions to enable/disable each rule
-- [ ] Visual cue for disabled rules (e.g., muted row or badge)
-- [ ] Matching logic: update `inpage.ts` and `content.ts` matchers to skip disabled rules
-- [ ] Bridge payload remains the same list; rules with `enabled=false` are still sent but ignored by matchers
+- [x] Extend `Rule` type with `enabled?: boolean` (default true)
+- [x] Migration: treat missing `enabled` as true (no storage rewrite needed)
+- [x] UI: add a toggle column to enable/disable each rule
+- [x] Visual cue for disabled rules (muted row)
+- [x] Matching logic: update in‑page and content matchers to skip disabled rules
+- [x] Bridge payload remains the same list; rules with `enabled=false` are sent but ignored by matchers
 
 ## Background Module Refactor
 

--- a/src/components/app/options.tsx
+++ b/src/components/app/options.tsx
@@ -95,6 +95,7 @@ function Dashboard() {
         isRegex: values.isRegex,
         delayMs: normalizedDelay,
         method: values.method,
+        enabled: true,
       };
       save([next, ...rules]);
     }

--- a/src/components/tabs/RulesTab.tsx
+++ b/src/components/tabs/RulesTab.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   Table,
   Tooltip,
+  Form as BsForm,
 } from "react-bootstrap";
 import { Plus, FunnelFill, QuestionCircle, Pencil, Trash3, Asterisk, BracesAsterisk } from "react-bootstrap-icons";
 
@@ -187,19 +188,20 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
                 <th scope="col" className="text-nowrap">Method</th>
                 <th scope="col" className="text-nowrap">Match Mode</th>
                 <th scope="col" className="text-end text-nowrap">Delay</th>
+                <th scope="col" className="text-nowrap text-end">Enabled</th>
                 <th scope="col" className="text-end text-nowrap">Actions</th>
               </tr>
             </thead>
             <tbody>
               {filteredRules.map((rule, index) => (
-                <tr key={rule.id}>
+                <tr key={rule.id} className={rule.enabled === false ? "text-muted" : undefined}>
                   <td className="text-nowrap col-index">
                     <span className="fw-semibold">#{index + 1}</span>
                   </td>
                   <td className="align-middle w-100">
                     <div className="d-flex align-items-center gap-2">
                       <span className="fw-semibold">{rule.pattern}</span>
-                      <span className="ms-auto">{renderConflictBadge(report ? report.byRuleId[rule.id] : undefined, rule.id, rule)}</span>
+                      <span className="ms-auto">{rule.enabled === false ? null : renderConflictBadge(report ? report.byRuleId[rule.id] : undefined, rule.id, rule)}</span>
                     </div>
                   </td>
                   <td className="align-middle text-nowrap">
@@ -220,6 +222,20 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
                   </td>
                   <td className="text-end align-middle text-nowrap">{rule.delayMs} ms</td>
                   <td className="text-end align-middle text-nowrap">
+                    <BsForm.Check
+                      type="switch"
+                      id={`rule-enabled-${rule.id}`}
+                      checked={rule.enabled !== false}
+                      onChange={(e: any) => {
+                        if (!onReorderRules) return;
+                        const next = rules.map(r => r.id === rule.id ? { ...r, enabled: e.target.checked } : r);
+                        onReorderRules(next);
+                      }}
+                      title={rule.enabled === false ? "Enable rule" : "Disable rule"}
+                      aria-label={rule.enabled === false ? "Enable rule" : "Disable rule"}
+                    />
+                  </td>
+                  <td className="text-end align-middle text-nowrap">
                     <ButtonGroup size="sm">
                       <Button variant="outline-secondary" onClick={() => onEditRule(rule)} title="Edit rule" aria-label="Edit rule">
                         <Pencil className="me-1" size={16} />
@@ -235,14 +251,14 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
               ))}
               {rules.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="text-center text-muted py-4">
+                  <td colSpan={7} className="text-center text-muted py-4">
                     No rules yet. Click "Add rule" to create one.
                   </td>
                 </tr>
               )}
               {rules.length > 0 && filteredRules.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="text-center text-muted py-4">
+                  <td colSpan={7} className="text-center text-muted py-4">
                     No rules match the selected filters.
                   </td>
                 </tr>

--- a/src/inpage/inpage.ts
+++ b/src/inpage/inpage.ts
@@ -27,6 +27,7 @@ function matches(url: string, method: string) {
   try { u = new URL(url, document.baseURI); } catch { return undefined; }
 
   for (const r of rules) {
+    if (r && r.enabled === false) continue;
     // method filter
     if (r.method && r.method.toUpperCase() !== upper) continue;
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,6 +6,7 @@ export type Rule = {
   isRegex?: boolean; // true => regex mode; false/undefined => wildcard (URLPattern)
   delayMs: number; // integer ms
   method?: string; // GET/POST/... or ""
+  enabled?: boolean; // default true; when false, rule is ignored
 };
 
 // Projects/domains (planning ahead). Adding types is safe and non-breaking.

--- a/src/utils/rules/matches.ts
+++ b/src/utils/rules/matches.ts
@@ -3,6 +3,7 @@ import { enabled, rules } from ".";
 export function matches(url: string, method: string) {
   if (!enabled) return undefined;
   return rules.find(r => {
+    if (r.enabled === false) return false;
     if (r.method && r.method.toUpperCase() !== method.toUpperCase()) return false;
     return r.isRegex
       ? new RegExp(r.pattern).test(url)

--- a/src/utils/rules/preview.ts
+++ b/src/utils/rules/preview.ts
@@ -28,9 +28,10 @@ export function testPattern(rule: Rule, url: string): boolean {
 export function getFirstMatch(rules: Rule[], url: string, method: string): MatchResult {
   const m = normalizeMethod(method || "GET");
   const u = url || "";
-  const winner = rules.find((r) => methodCovers(r.method, m) && testPattern(r, u));
+  const active = rules.filter(r => r.enabled !== false);
+  const winner = active.find((r) => methodCovers(r.method, m) && testPattern(r, u));
   if (!winner) return null;
-  const index = rules.findIndex((r) => r.id === winner.id);
+  const index = active.findIndex((r) => r.id === winner.id);
   return index >= 0 ? { index, rule: winner } : null;
 }
 
@@ -40,8 +41,9 @@ export function getEvaluationPath(rules: Rule[], url: string, method: string): E
   const steps: EvalStep[] = [];
   const m = normalizeMethod(method || "GET");
   const u = url || "";
-  for (let i = 0; i < rules.length; i++) {
-    const r = rules[i];
+  const active = rules.filter(r => r.enabled !== false);
+  for (let i = 0; i < active.length; i++) {
+    const r = active[i];
     const idx = i + 1;
     const methodOk = methodCovers(r.method, m);
     if (!methodOk) { steps.push({ idx, methodOk, patternOk: false }); continue; }
@@ -61,4 +63,3 @@ export function getEvaluationPath(rules: Rule[], url: string, method: string): E
   }
   return steps;
 }
-

--- a/tests/utils/rules/preview.test.ts
+++ b/tests/utils/rules/preview.test.ts
@@ -41,5 +41,21 @@ describe("rules preview helpers", () => {
     expect(steps[1].methodOk).toBe(true);
     expect(steps[1].patternOk).toBe(true);
   });
-});
 
+  test("disabled rules are ignored by preview helpers", () => {
+    const rules: Rule[] = [
+      mk("disabled", "api", false, "GET"),
+      mk("win", "/api/v1", false, "GET"),
+    ];
+    // Mark the first rule disabled
+    (rules[0] as any).enabled = false;
+
+    const res = getFirstMatch(rules, "https://x.com/api/v1", "GET");
+    expect(res?.rule.id).toBe("win");
+
+    const steps = getEvaluationPath(rules, "https://x.com/api/v1", "GET");
+    // Only the enabled rule should be evaluated
+    expect(steps.length).toBe(1);
+    expect(steps[0].patternOk).toBe(true);
+  });
+});


### PR DESCRIPTION
# Per‑Rule Enable/Disable + Matcher/Preview Integration

## Summary
This branch introduces per‑rule enable/disable across the extension. Rules can now be toggled on/off directly in the Rules table. Disabled rules are ignored by the matching logic and previews, allowing users to experiment without deleting rules. The change is storage‑compatible (missing `enabled` implies enabled), and the UI communicates state clearly with a dedicated toggle and muted styling.

## What’s Included
We added an `enabled?: boolean` flag to the `Rule` type and updated all matching paths to ignore rules with `enabled === false`. The Options dashboard gained a new “Enabled” column with a switch per row. New rules default to enabled. The rule preview helpers (`getFirstMatch`, `getEvaluationPath`) now filter out disabled rules so simulations reflect only active rules. A focused unit test covers the updated preview behavior. The backlog was updated to mark this feature as complete.

### Behavior and UX Notes
- Disabled rules do not participate in matching for Fetch/XHR interceptors or in‑page matching.
- The Rules table shows a switch in a new “Enabled” column and dims disabled rows; conflict badges are suppressed for disabled rows.
- Adding a rule sets `enabled: true` by default, so existing flows are unchanged unless a user toggles a rule off.
- Storage migration is non‑breaking: existing rules without `enabled` are treated as enabled.

### Testing
- Component/UI tests are deferred per our current focus.
- Added a unit test to ensure the preview helpers skip disabled rules and still identify the correct winner and evaluation steps.

## Files Changed
- `src/types/types.ts` — Add `enabled?: boolean` to `Rule` (default treated as true when missing).
- `src/components/tabs/RulesTab.tsx` — Add an “Enabled” column with a per‑row switch, mute disabled rows, and hide conflict badge when disabled. Adjust empty‑state colSpans.
- `src/components/app/options.tsx` — Default new rules to `enabled: true` on creation.
- `src/utils/rules/matches.ts` — Skip rules where `enabled === false` in the shared content matcher.
- `src/utils/rules/preview.ts` — Filter out disabled rules in `getFirstMatch` and `getEvaluationPath` so previews reflect active rules.
- `src/inpage/inpage.ts` — Ignore disabled rules in the in‑page matcher used by fetch/XHR patches.
- `tests/utils/rules/preview.test.ts` — New test asserting disabled rules are ignored by preview helpers.
- `docs/TODO.md` — Mark “Enable/Disable Per Rule” as completed and capture implementation notes.

## Rationale
Per‑rule enable/disable lets developers and QA quickly toggle experiments without losing configuration, and pairs well with cloning projects for safe iteration. Ignoring disabled rules in both matching and preview ensures consistent behavior between simulation and runtime.

## Compatibility
- Backwards compatible with existing stored rules (no migration write needed).
- UI additions are additive and do not change other flows.

