### PR TITLE
Rules Table Polish

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,11 +57,16 @@ This is the live backlog. Completed items have been moved to `TODO.v0.0.1.md`.
 - [x] Rules actions icon‑only (Edit/Delete) with visually‑hidden labels
 - [x] Help tooltip icon for rules ordering next to “Current rules”
 
-### Rules Table polish (next)
+### Rules Table polish
 
-- [ ] Conflict badges: replace "Never matches" / "May not match" text with icon-only badges and keep details in a tooltip/popover.
-- [ ] Columns: move Method before URL / Path; set a fixed width for method badges sufficient for "DELETE".
-- [ ] Delay column: rename header to "Delay (ms)"; in rows, display just the number (no "ms" suffix).
+- [x] Conflict badges: replace text with icon-only badges and show details via tooltip.
+  - [x] Icons are outline-only (transparent fill) with white stroke so badge color shows through.
+- [x] Columns: move Method before URL / Path; set a fixed width for method badges sufficient for "DELETE".
+- [x] Delay column: rename header to "Delay (ms)"; in rows, display just the number (no "ms" suffix).
+
+### Theme/Text visibility
+
+- [x] Global text color fix: ensure headings, paragraphs, labels, and inputs render in black for visibility.
 
 ## QA & Validation
 

--- a/src/components/tabs/RulesTab.tsx
+++ b/src/components/tabs/RulesTab.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
   Form as BsForm,
 } from "react-bootstrap";
-import { Plus, FunnelFill, QuestionCircle, Pencil, Trash3, Asterisk, BracesAsterisk } from "react-bootstrap-icons";
+import { Plus, FunnelFill, QuestionCircle, Pencil, Trash3, Asterisk, BracesAsterisk, ExclamationOctagon, ExclamationTriangle } from "react-bootstrap-icons";
 
 import type { Rule } from "../../types/types";
 import { methodVariant, methodIcon, matchModeBadgeClasses } from "../../utils/rules-ui";
@@ -73,7 +73,14 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
     return (
       <OverlayTrigger placement="top" overlay={overlay} delay={{ show: 150, hide: 0 }}>
         <div className="d-inline-flex align-items-center gap-2">
-          <Badge bg={variant} className="me-2" title={label} aria-label={label}>{label}</Badge>
+          <Badge
+            bg={variant}
+            className="d-inline-flex align-items-center justify-content-center p-1 conflict-badge-icon"
+            title={label}
+            aria-label={label}
+          >
+            {hasDef ? <ExclamationOctagon size={14} className="conflict-icon-outline" /> : <ExclamationTriangle size={14} className="conflict-icon-outline" />}
+          </Badge>
           {reason && onReorderRules ? (
             <Button
               size="sm"
@@ -184,10 +191,10 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
             <thead>
               <tr>
                 <th scope="col" className="text-nowrap col-index" aria-label="Order"></th>
+                <th scope="col" className="text-nowrap col-method">Method</th>
                 <th scope="col" className="w-100">URL / Path</th>
-                <th scope="col" className="text-nowrap">Method</th>
                 <th scope="col" className="text-nowrap">Match Mode</th>
-                <th scope="col" className="text-end text-nowrap">Delay</th>
+                <th scope="col" className="text-end text-nowrap">Delay (ms)</th>
                 <th scope="col" className="text-nowrap text-end">Enabled</th>
                 <th scope="col" className="text-end text-nowrap">Actions</th>
               </tr>
@@ -198,19 +205,19 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
                   <td className="text-nowrap col-index">
                     <span className="fw-semibold">#{index + 1}</span>
                   </td>
-                  <td className="align-middle w-100">
-                    <div className="d-flex align-items-center gap-2">
-                      <span className="fw-semibold">{rule.pattern}</span>
-                      <span className="ms-auto">{rule.enabled === false ? null : renderConflictBadge(report ? report.byRuleId[rule.id] : undefined, rule.id, rule)}</span>
-                    </div>
-                  </td>
-                  <td className="align-middle text-nowrap">
-                    <Badge bg={methodVariant(rule.method)}>
+                  <td className="align-middle text-nowrap col-method">
+                    <Badge bg={methodVariant(rule.method)} className="method-badge text-uppercase">
                       {methodIcon(rule.method) ? (
                         <span className="me-1" aria-hidden="true">{methodIcon(rule.method)}</span>
                       ) : null}
                       {rule.method || "Any"}
                     </Badge>
+                  </td>
+                  <td className="align-middle w-100">
+                    <div className="d-flex align-items-center gap-2">
+                      <span className="fw-semibold">{rule.pattern}</span>
+                      <span className="ms-auto">{rule.enabled === false ? null : renderConflictBadge(report ? report.byRuleId[rule.id] : undefined, rule.id, rule)}</span>
+                    </div>
                   </td>
                   <td className="align-middle text-nowrap">
                     <Badge className={matchModeBadgeClasses(!!rule.isRegex)}>
@@ -220,7 +227,7 @@ export default function RulesTab({ rules, onAddRule, onEditRule, onRequestDelete
                       {rule.isRegex ? "Regex" : "Wildcard"}
                     </Badge>
                   </td>
-                  <td className="text-end align-middle text-nowrap">{rule.delayMs} ms</td>
+                  <td className="text-end align-middle text-nowrap">{rule.delayMs}</td>
                   <td className="text-end align-middle text-nowrap">
                     <BsForm.Check
                       type="switch"

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -17,9 +17,9 @@
   z-index: 1019; /* just under .navbar's 1020 */
 }
 
-/* Rules table layout: URL/Path column (2nd col) expands, index stays minimal */
-.rules-table th:nth-child(2),
-.rules-table td:nth-child(2) {
+/* Rules table layout: URL/Path column (3rd col) expands, index stays minimal */
+.rules-table th:nth-child(3),
+.rules-table td:nth-child(3) {
   width: 100%;
 }
 .rules-table th.col-index,
@@ -27,9 +27,49 @@
   width: 1%;
   white-space: nowrap;
 }
-.rules-table th:not(:nth-child(2)),
-.rules-table td:not(:nth-child(2)) {
+.rules-table th:not(:nth-child(3)),
+.rules-table td:not(:nth-child(3)) {
   white-space: nowrap;
+}
+
+/* Method column: keep compact width and fixed-size badge */
+.rules-table th.col-method,
+.rules-table td.col-method {
+  width: 1%;
+  white-space: nowrap;
+}
+.method-badge {
+  display: inline-block;
+  min-width: 72px; /* fits DELETE */
+  text-align: center;
+}
+
+/* Conflict badge icon: tighter size */
+.conflict-badge-icon {
+  width: 22px;
+  height: 22px;
+}
+
+/* Make conflict icons outlined (no fill), white strokes on colored badges */
+.conflict-icon-outline {
+  color: #fff !important;
+  fill: none !important;
+}
+.conflict-icon-outline path {
+  fill: none !important;
+  stroke: currentColor !important;
+  stroke-width: 2px;
+}
+
+/* Global text color fix: ensure readable black text across headings, labels, inputs */
+:root,
+[data-bs-theme="light"] {
+  --bs-body-color: #000 !important;
+  --bs-heading-color: #000 !important;
+}
+
+body, label, .form-label, .form-control, .form-select, .form-check-label {
+  color: #000 !important;
 }
 
 /* Dropdown: suppress ALL hover/active color changes (bg + text) */


### PR DESCRIPTION
# Per‑Rule Enable/Disable, Rules Table Polish, and Text Visibility Fix

## Summary
This branch adds per‑rule enable/disable, polishes the Rules table for clarity, and fixes a visibility issue by forcing global text to render in black. Together, these changes make it easier to experiment with throttling configurations, quickly interpret conflict states, and read the UI in varied environments/themes.

## What’s Included
We introduced an `enabled?: boolean` flag on rules and wired it through the matchers so disabled rules are ignored at runtime. The Options dashboard gained a new Enabled column with per‑row toggles, and new rules default to enabled. The Rules table was refined: conflict badges are icon‑only with tooltips, the Method column now sits before URL/Path with a fixed‑width badge, and Delay formatting is clearer (header "Delay (ms)" and numeric values only). Finally, text color across headings, labels, and inputs is forced to black for consistent readability.

### Feature Details
- Per‑rule enable/disable
  - Toggle rules on/off without deleting them. Disabled rules are ignored by matchers and previews.
  - UI switch per row; disabled rows render muted; conflict icons suppressed for disabled rows.
  - New rules are created enabled by default; existing rules without `enabled` are treated as enabled.
- Rules table polish
  - Conflict badges: icon‑only (octagon = definite, triangle = possible) with tooltip text; outlined white icons so badge color shows through.
  - Column order: Index, Method, URL/Path, Match Mode, Delay (ms), Enabled, Actions.
  - Method badge has a fixed width (fits "DELETE").
  - Delay column header clarified; rows show numbers only.
- Text visibility
  - Force global text (headings, paragraphs, labels, inputs) to black to avoid washed‑out/white text under certain themes.

### Testing
- Component tests are deferred. Added a focused unit test ensuring preview helpers skip disabled rules and still identify the correct winner and evaluation steps.

## Files Changed
- `src/types/types.ts` — Add `enabled?: boolean` to `Rule`.
- `src/components/tabs/RulesTab.tsx` — New Enabled column with per‑row switches; muted styling for disabled rows; icon‑only conflict badges (outlined icons) with tooltip and action; move Method before URL/Path; update Delay header/formatting.
- `src/components/app/options.tsx` — New rules default to `enabled: true`.
- `src/utils/rules/matches.ts` — Skip rules with `enabled === false` in the shared content matcher.
- `src/utils/rules/preview.ts` — `getFirstMatch`/`getEvaluationPath` ignore disabled rules so simulations reflect the active set.
- `src/inpage/inpage.ts` — Ignore disabled rules in the in‑page matcher used by fetch/XHR hooks.
- `src/theme/styles.css` — Table layout tweaks (method column, badge sizing), conflict icon outline styling, and global text color set to black.
- `tests/utils/rules/preview.test.ts` — Add unit test covering disabled rules behavior in preview helpers.
- `docs/TODO.md` — Mark per‑rule enable/disable as complete; record Rules table polish and text visibility updates.

## Rationale and Compatibility
These changes reduce friction when experimenting with throttling rules and improve scanability. Storage remains backward compatible: rules without an `enabled` property behave as enabled. UI changes are additive and non‑breaking.

